### PR TITLE
Add safetensors/kohya-ss support

### DIFF
--- a/inspect_embedding_training.py
+++ b/inspect_embedding_training.py
@@ -207,13 +207,12 @@ def decode_kohya_ss_embedding(embed: dict, metadata: dict):
     vector_data = {}
     # {'emb_params': tensor([[ 5.9789e-01,  2.1925e-01, -1.1750e-01, -2.1693e-01, -1.508
     tensors = embed["emb_params"]
-    step = 500
     vector_data = torch.flatten(tensors).tolist()
     magnitude = get_vector_data_magnitude(vector_data)
     strength = get_vector_data_strength(vector_data)
     vectors_per_token = int(len(vector_data) / DIMS_PER_VECTOR)
 
-    return metadata.get("ss_output_name", ""), step, metadata.get("sshs_model_hash"), metadata.get("ss_sd_model_name", ""), metadata.get("ss_output_name", ""), tensors, vectors_per_token, magnitude, strength
+    return metadata.get("ss_output_name", ""), metadata.get("ss_max_train_steps"), metadata.get("sshs_model_hash"), metadata.get("ss_sd_model_name", ""), metadata.get("ss_output_name", ""), tensors, vectors_per_token, magnitude, strength
 
 
 def decode_a1111_embedding(embed: dict):

--- a/inspect_embedding_training.py
+++ b/inspect_embedding_training.py
@@ -165,13 +165,11 @@ def get_embedding_file_data(embedding_file_name: str) -> (str, int, str, str, st
                 raise ImportError(f"The embedding is in safetensors format and it is not installed, use `pip install safetensors`: {e}")
 
             embed = {}
-            metadata = None
+            metadata = {}
             with safe_open(embedding_file_name, framework="pt", device="cpu") as f:
                 for k in f.keys():
                     embed[k] = f.get_tensor(k)
-                metadata = f.metadata()
-            if metadata is None:
-                print("We could not find enough metadata from this safetensors file")
+                metadata = f.metadata() or {}
         else:
             embed = torch.load(embedding_file_name, map_location=torch.device("cpu"))
             metadata = embed
@@ -197,10 +195,10 @@ def get_embedding_file_data(embedding_file_name: str) -> (str, int, str, str, st
     magnitude = None
     strength = None
     vectors_per_token = None
-    if "string_to_token" in embed.keys():
-        return decode_a1111_embedding(embed)
-    else:
+    if "emb_params" in embed.keys():
         return decode_kohya_ss_embedding(embed, metadata)
+    else:
+        return decode_a1111_embedding(embed)
 
 
 def decode_kohya_ss_embedding(embed: dict, metadata: dict):

--- a/inspect_embedding_training.py
+++ b/inspect_embedding_training.py
@@ -209,12 +209,11 @@ def decode_kohya_ss_embedding(embed: dict, metadata: dict):
     tensors = embed["emb_params"]
     step = 500
     vector_data = torch.flatten(tensors).tolist()
-    tensors = embed["string_to_param"][token]
     magnitude = get_vector_data_magnitude(vector_data)
     strength = get_vector_data_strength(vector_data)
-    vectors_per_token = int(len(vector_data[step]) / DIMS_PER_VECTOR)
+    vectors_per_token = int(len(vector_data) / DIMS_PER_VECTOR)
 
-    return {}, {}, metadata.get("ss_output_name", ""), step, metadata.get("sshs_model_hash"), metadata.get("ss_sd_model_name", ""), metadata.get("ss_output_name", ""), vectors_per_token, magnitude, strength
+    return metadata.get("ss_output_name", ""), step, metadata.get("sshs_model_hash"), metadata.get("ss_sd_model_name", ""), metadata.get("ss_output_name", ""), tensors, vectors_per_token, magnitude, strength
 
 
 def decode_a1111_embedding(embed: dict):

--- a/inspect_embedding_training.py
+++ b/inspect_embedding_training.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import copy
 import os
 import csv
@@ -216,8 +214,8 @@ def decode_a1111_embedding(embed: dict):
     string_to_param = embed["string_to_param"]  #{'*': tensor([[ 0.0178,  0.0123, -0.0003,  ...,  0.0420, -0.0379, -0.0294], [-0.0085, -0.0037,  0.0069,  ...,  0.0240, -0.0191,  0.0299], [ 0.0163, -0.0113,  0.0093,  ...,  0.0757,  0.0006, -0.0272]], requires_grad=True)}
     internal_name = embed["name"]               #EmbedTest
     step = embed["step"] + 1                    #1000
-    sd_checkpoint_hash = embed["sd_checkpoint"] or "" #a9263745
-    sd_checkpoint_name = embed["sd_checkpoint_name"] or ""   #v1-5-pruned
+    sd_checkpoint_hash = embed["sd_checkpoint"] #a9263745
+    sd_checkpoint_name = embed["sd_checkpoint_name"]   #v1-5-pruned
     token = list(string_to_token.keys())[0]  #"*"
 
     if file_extension == ".pt":


### PR DESCRIPTION
I was wanting to get safetensors and kohya-ss support to be part of this tool. I hacked together something that "works" but needs some more work to make it really work. Would this be something you're interested in? I can clean up the hacks (like the 2 decodes, hardcode some random step).

File format for kohya-ss (so we don't have a lot of the meta data here):

```
{'emb_params': tensor([[ 5.9789e-01,  2.1925e-01, -1.1750e-01, -2.1693e-01, -1.5086e+00,
         -3.9739e-01, -4.1892e-01, -3.2805e-01,  1.0100e-01,  5.4531e-01,
          4.0642e-01, -3.0439e-01,  2.1693e-01, -5.8162e-01,  2.7260e-01,
          4.9954e-01,  6.2714e-01,  3.3210e-01, -2.2008e-01, -1.5614e-01,
         -5.5246e-01, -3.3151e-01,  5.7267e-02, -2.4922e-01,  7.6487e-01,
          1.6880e-01,  5.0435e-01, -4.8288e-01, -3.5610e-02, -3.1967e-01,
         -7.0646e-01,  6.6747e-01,  5.3893e-01, -1.5621e-02, -2.9104e-01,
         -4.2398e-02,  1.7977e-01, -3.7368e-01, -2.7377e-01,  7.2920e-01,
          1.4336e-01,  1.8718e-01,  4.6177e-02,  1.5627e-01, -4.1976e-01,
         -2.3099e-01,  1.5557e-01, -5.3178e-02, -5.6574e-01, -3.5710e-01,
          5.1875e-01,  1.1630e-01, -2.8165e-01,  4.6516e-01, -6.2688e-01,
         ...
```

```
python inspect_embedding_training.py --file /mnt/900/training/scarjo-subject-1-5/scarjo-subject2-000040.safetensors
Data for embedding file: /mnt/900/training/scarjo-subject-1-5/scarjo-subject2-000040.safetensors
  Internal name:
  Model name it was trained on:
  Model hash it was trained on:
  Token:
  Vectors per token: 1
  Total training steps: 500
  Average vector strength: 0.3729
  Average vector magnitude: 13.0083
```

Example kohya safetensors file: 
[scarjo-subject2.zip](https://github.com/Zyin055/Inspect-Embedding-Training/files/10669202/scarjo-subject2.zip)

We can probably add more meta info to the exported file in kohya-ss to make it more expressive to improve this functionality.